### PR TITLE
Apply monochrome theme and simplify user display

### DIFF
--- a/src/alf/themes.ts
+++ b/src/alf/themes.ts
@@ -10,9 +10,9 @@ import {
 
 const themes = createThemes({
   hues: {
-    primary: BLUE_HUE,
-    negative: RED_HUE,
-    positive: GREEN_HUE,
+    primary: 0, // Monochrome - no hue
+    negative: 0, // Monochrome - no hue
+    positive: 0, // Monochrome - no hue
   },
 })
 
@@ -60,7 +60,7 @@ export function createThemes({
   dim: Theme
 } {
   const color = {
-    like: '#ec4899',
+    like: '#666666', // Monochrome gray instead of pink
     trueBlack: '#000000',
 
     gray_0: `hsl(${hues.primary}, 20%, ${defaultScale[14]}%)`,

--- a/src/components/VideoPostCard.tsx
+++ b/src/components/VideoPostCard.tsx
@@ -12,7 +12,7 @@ import {
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {sanitizeHandle} from '#/lib/strings/handles'
+import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {formatCount} from '#/view/com/util/numeric/format'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {VideoFeedSourceContext} from '#/screens/VideoFeed/types'
@@ -110,7 +110,7 @@ export function VideoPostCard({
             t.atoms.text_contrast_medium,
           ]}
           numberOfLines={1}>
-          {sanitizeHandle(post.author.handle, '@')}
+          {sanitizeDisplayName(post.author.displayName || post.author.handle)}
         </Text>
       </View>
     </View>
@@ -318,7 +318,7 @@ export function VideoPostCardTextPlaceholder({
                 t.atoms.text_contrast_medium,
               ]}
               numberOfLines={1}>
-              {sanitizeHandle(author.handle, '@')}
+              {sanitizeDisplayName(author.displayName || author.handle)}
             </Text>
           </View>
         ) : (

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -951,7 +951,7 @@ function ExpandedAuthorCard({author}: {author: Author}) {
               a.flex_shrink,
               t.atoms.text_contrast_medium,
             ]}>
-            {sanitizeHandle(author.profile.handle, '@')}
+            {sanitizeDisplayName(author.profile.displayName || author.profile.handle)}
           </Text>
         </View>
       </View>

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -379,8 +379,7 @@ let FeedItemInner = ({
                             style={pal.textLight}
                             lineHeight={1.2}>
                             {sanitizeDisplayName(
-                              reason.by.displayName ||
-                                sanitizeHandle(reason.by.handle),
+                              reason.by.displayName || reason.by.handle,
                               moderation.ui('displayName'),
                             )}
                           </Text>

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -121,22 +121,6 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
                 />
               </View>
             )}
-            <WebOnlyInlineLinkText
-              emoji
-              numberOfLines={1}
-              to={profileLink}
-              label={_(msg`View profile`)}
-              disableMismatchWarning
-              disableUnderline
-              onPress={onBeforePressAuthor}
-              style={[
-                a.text_md,
-                t.atoms.text_contrast_medium,
-                a.leading_tight,
-                {flexShrink: 10},
-              ]}>
-              {NON_BREAKING_SPACE + sanitizeHandle(handle, '@')}
-            </WebOnlyInlineLinkText>
           </View>
         </ProfileHoverCard>
 


### PR DESCRIPTION
Implement a monochrome color scheme and remove usernames/handles from timeline posts to declutter the UI.

The app now features a Threads-like monochrome aesthetic and displays only display names on timeline posts, as requested by the user to reduce visual clutter.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4b2a4a3-703d-472c-8e8c-170dcf355a66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4b2a4a3-703d-472c-8e8c-170dcf355a66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

