### PR TITLE
Implement fanout service for microservices

### DIFF
--- a/time-server/src/services/fanout_service/CMakeLists.txt
+++ b/time-server/src/services/fanout_service/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.16)
+project(fanout_service CXX)
+
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/proto/fanout_service.proto)
+set(GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
+file(MAKE_DIRECTORY ${GENERATED_DIR})
+
+set(PROTO_SRCS ${GENERATED_DIR}/fanout_service.pb.cc)
+set(PROTO_HDRS ${GENERATED_DIR}/fanout_service.pb.h)
+set(GRPC_SRCS ${GENERATED_DIR}/fanout_service.grpc.pb.cc)
+set(GRPC_HDRS ${GENERATED_DIR}/fanout_service.grpc.pb.h)
+
+add_custom_command(
+  OUTPUT ${PROTO_SRCS} ${PROTO_HDRS} ${GRPC_SRCS} ${GRPC_HDRS}
+  COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/proto
+    --cpp_out=${GENERATED_DIR}
+    --grpc_out=${GENERATED_DIR}
+    --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
+    ${PROTO_SRC}
+  DEPENDS ${PROTO_SRC}
+  COMMENT "Generating gRPC sources for fanout_service.proto"
+)
+
+add_library(fanout_proto ${PROTO_SRCS} ${GRPC_SRCS})
+target_include_directories(fanout_proto PUBLIC ${GENERATED_DIR})
+target_link_libraries(fanout_proto PUBLIC gRPC::grpc++ protobuf::libprotobuf)
+
+add_executable(fanout_service
+  main.cpp
+  service.cpp
+  controllers/fanout_controller.cpp
+  transport.cpp
+)
+
+target_include_directories(fanout_service PUBLIC ${GENERATED_DIR})
+target_link_libraries(fanout_service PRIVATE fanout_proto gRPC::grpc++ protobuf::libprotobuf spdlog::spdlog)
+

--- a/time-server/src/services/fanout_service/controllers/fanout_controller.cpp
+++ b/time-server/src/services/fanout_service/controllers/fanout_controller.cpp
@@ -1,0 +1,28 @@
+#include "fanout_controller.h"
+
+#include <spdlog/spdlog.h>
+
+namespace time::fanout_service::controllers {
+
+grpc::Status FanoutController::Push(grpc::ServerContext*, const time::fanout::FanoutRequest* req, time::fanout::FanoutResponse* resp) {
+	std::vector<time::fanout::Event> events;
+	events.reserve(req->batch().events_size());
+	for (const auto& e : req->batch().events()) events.push_back(e);
+	bool ok = push_->Ingest(events);
+	resp->set_accepted(static_cast<uint32_t>(ok ? events.size() : 0));
+	resp->set_rejected(static_cast<uint32_t>(ok ? 0 : events.size()));
+	return grpc::Status::OK;
+}
+
+grpc::Status FanoutController::Health(grpc::ServerContext*, const time::fanout::HealthRequest*, time::fanout::HealthResponse* resp) {
+	resp->set_status(health_cb_());
+	return grpc::Status::OK;
+}
+
+grpc::Status FanoutController::Metrics(grpc::ServerContext*, const time::fanout::MetricsRequest*, time::fanout::MetricsResponse* resp) {
+	resp->set_prometheus(metrics_cb_());
+	return grpc::Status::OK;
+}
+
+} // namespace time::fanout_service::controllers
+

--- a/time-server/src/services/fanout_service/controllers/fanout_controller.h
+++ b/time-server/src/services/fanout_service/controllers/fanout_controller.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+
+#include "proto/fanout_service.grpc.pb.h"
+#include "../processors/push_processor.h"
+
+namespace time::fanout_service::controllers {
+
+class FanoutController final : public time::fanout::FanoutService::Service {
+public:
+	FanoutController(std::shared_ptr<processors::PushProcessor> push,
+					std::function<std::string()> metrics_cb,
+					std::function<std::string()> health_cb)
+		: push_(std::move(push)), metrics_cb_(std::move(metrics_cb)), health_cb_(std::move(health_cb)) {}
+
+	grpc::Status Push(grpc::ServerContext*, const time::fanout::FanoutRequest* req, time::fanout::FanoutResponse* resp) override;
+	grpc::Status Health(grpc::ServerContext*, const time::fanout::HealthRequest*, time::fanout::HealthResponse* resp) override;
+	grpc::Status Metrics(grpc::ServerContext*, const time::fanout::MetricsRequest*, time::fanout::MetricsResponse* resp) override;
+
+private:
+	std::shared_ptr<processors::PushProcessor> push_;
+	std::function<std::string()> metrics_cb_;
+	std::function<std::string()> health_cb_;
+};
+
+} // namespace time::fanout_service::controllers
+

--- a/time-server/src/services/fanout_service/main.cpp
+++ b/time-server/src/services/fanout_service/main.cpp
@@ -1,0 +1,38 @@
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+
+#include "service.h"
+
+static volatile std::sig_atomic_t g_stop = 0;
+static void HandleSig(int) { g_stop = 1; }
+
+static std::string GetEnvOr(const char* key, const std::string& def) {
+	const char* v = std::getenv(key);
+	return v ? std::string(v) : def;
+}
+
+int main() {
+	std::signal(SIGINT, HandleSig);
+	std::signal(SIGTERM, HandleSig);
+
+	time::fanout_service::Config cfg;
+	cfg.bind_address = GetEnvOr("FANOUT_BIND", "0.0.0.0:6015");
+	if (const char* cap = std::getenv("FANOUT_QUEUE_CAPACITY")) cfg.queue_capacity = static_cast<size_t>(std::strtoull(cap, nullptr, 10));
+	if (const char* bs = std::getenv("FANOUT_BATCH_SIZE")) cfg.batch_size = static_cast<uint32_t>(std::strtoul(bs, nullptr, 10));
+	if (const char* pt = std::getenv("FANOUT_POLL_TIMEOUT_MS")) cfg.poll_timeout_ms = static_cast<uint32_t>(std::strtoul(pt, nullptr, 10));
+	if (const char* pr = std::getenv("FANOUT_PUSH_RETRIES")) cfg.push_retries = static_cast<size_t>(std::strtoull(pr, nullptr, 10));
+	cfg.registry_path_or_json = GetEnvOr("FANOUT_REGISTRY", "");
+
+	time::fanout_service::FanoutServer server(cfg);
+	if (!server.Start()) {
+		std::cerr << "Failed to start fanout_service" << std::endl;
+		return 1;
+	}
+	std::cout << "fanout_service listening on " << cfg.bind_address << std::endl;
+	while (!g_stop) { std::this_thread::sleep_for(std::chrono::milliseconds(200)); }
+	server.Stop();
+	return 0;
+}
+

--- a/time-server/src/services/fanout_service/processors/pull_processor.h
+++ b/time-server/src/services/fanout_service/processors/pull_processor.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <spdlog/spdlog.h>
+
+#include "proto/fanout_service.pb.h"
+#include "queues/fanout_queue.h"
+#include "../transport.h"
+
+namespace time::fanout_service::processors {
+
+class PullProcessor {
+public:
+	using QueueType = queues::BoundedQueue<time::fanout::Event>;
+
+	PullProcessor(std::shared_ptr<QueueType> queue,
+				std::shared_ptr<Transport> transport,
+				std::function<std::vector<std::string>(const time::fanout::Event&)> router,
+				uint32_t batch_size,
+				uint32_t poll_timeout_ms)
+		: queue_(std::move(queue)), transport_(std::move(transport)), router_(std::move(router)),
+		  batch_size_(batch_size), poll_timeout_ms_(poll_timeout_ms) {}
+
+	void Start() {
+		if (running_.exchange(true)) return;
+		worker_ = std::thread([this]{ Run(); });
+	}
+
+	void Stop() {
+		if (!running_.exchange(false)) return;
+		queue_->Shutdown();
+		if (worker_.joinable()) worker_.join();
+	}
+
+private:
+	void Run() {
+		std::mt19937_64 rng(std::random_device{}());
+		std::uniform_int_distribution<int> jitter(0, 50);
+		while (running_.load()) {
+			auto batch = queue_->PopBatch(batch_size_, poll_timeout_ms_);
+			if (batch.empty()) continue;
+			// Group by downstream service
+			std::unordered_map<std::string, std::vector<time::fanout::Event>> by_service;
+			for (auto& e : batch) {
+				for (const auto& svc : router_(e)) {
+					by_service[svc].push_back(e);
+				}
+			}
+			// Send with retries
+			for (auto& kv : by_service) {
+				const std::string& svc = kv.first;
+				auto& evs = kv.second;
+				int attempt = 0;
+				const int max_attempts = 6;
+				while (attempt < max_attempts) {
+					bool ok = transport_->SendBatch(svc, evs).get();
+					if (ok) break;
+					int backoff_ms = (1 << attempt) * 20 + jitter(rng);
+					std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+					++attempt;
+				}
+				if (attempt >= max_attempts) {
+					spdlog::error("Fanout failed to service {} after {} attempts", svc, max_attempts);
+				}
+			}
+		}
+	}
+
+	std::shared_ptr<QueueType> queue_;
+	std::shared_ptr<Transport> transport_;
+	std::function<std::vector<std::string>(const time::fanout::Event&)> router_;
+	uint32_t batch_size_;
+	uint32_t poll_timeout_ms_;
+	std::atomic<bool> running_{false};
+	std::thread worker_;
+};
+
+} // namespace time::fanout_service::processors
+

--- a/time-server/src/services/fanout_service/processors/push_processor.h
+++ b/time-server/src/services/fanout_service/processors/push_processor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "proto/fanout_service.pb.h"
+#include "queues/fanout_queue.h"
+
+namespace time::fanout_service::processors {
+
+class PushProcessor {
+public:
+	using QueueType = queues::BoundedQueue<time::fanout::Event>;
+
+	PushProcessor(std::shared_ptr<QueueType> queue, size_t max_retries)
+		: queue_(std::move(queue)), max_retries_(max_retries) {}
+
+	bool Ingest(const std::vector<time::fanout::Event>& events) {
+		size_t rejected = 0;
+		for (const auto& e : events) {
+			bool ok = false;
+			for (size_t attempt = 0; attempt < max_retries_ && !ok; ++attempt) {
+				ok = queue_->TryPush(e);
+				if (!ok) std::this_thread::sleep_for(std::chrono::microseconds(200));
+			}
+			if (!ok) ++rejected;
+		}
+		return rejected == 0;
+	}
+
+private:
+	std::shared_ptr<QueueType> queue_;
+	size_t max_retries_;
+};
+
+} // namespace time::fanout_service::processors
+

--- a/time-server/src/services/fanout_service/proto/fanout_service.proto
+++ b/time-server/src/services/fanout_service/proto/fanout_service.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package time.fanout;
+
+option cc_enable_arenas = true;
+
+message Attribute {
+  string key = 1;
+  string value = 2;
+}
+
+message Event {
+  string id = 1;              // unique event id
+  string type = 2;            // e.g., note.created, user.updated
+  string source = 3;          // originating service
+  int64 timestamp_ms = 4;     // unix epoch ms
+  bytes payload = 5;          // raw payload (JSON or protobuf-encoded)
+  repeated Attribute attributes = 6; // routing hints
+}
+
+message EventBatch {
+  repeated Event events = 1;
+}
+
+message FanoutRequest {
+  EventBatch batch = 1;
+}
+
+message FanoutResponse {
+  uint32 accepted = 1;  // number accepted for processing
+  uint32 rejected = 2;  // dropped due to backpressure or validation
+}
+
+message HealthRequest {}
+message HealthResponse {
+  string status = 1; // HEALTHY/DEGRADED/UNHEALTHY
+}
+
+message MetricsRequest {}
+message MetricsResponse {
+  // Prometheus exposition text format
+  string prometheus = 1;
+}
+
+service FanoutService {
+  rpc Push(FanoutRequest) returns (FanoutResponse);
+  rpc Health(HealthRequest) returns (HealthResponse);
+  rpc Metrics(MetricsRequest) returns (MetricsResponse);
+}
+

--- a/time-server/src/services/fanout_service/queues/fanout_queue.h
+++ b/time-server/src/services/fanout_service/queues/fanout_queue.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace time::fanout_service::queues {
+
+template <typename T>
+class BoundedQueue {
+public:
+	explicit BoundedQueue(size_t capacity)
+		: capacity_(capacity) {}
+
+	bool TryPush(T item) {
+		std::unique_lock<std::mutex> lk(mutex_);
+		if (queue_.size() >= capacity_) return false;
+		queue_.push_back(std::move(item));
+		cv_.notify_one();
+		return true;
+	}
+
+	std::vector<T> PopBatch(uint32_t max_items, uint32_t timeout_ms) {
+		std::unique_lock<std::mutex> lk(mutex_);
+		if (!cv_.wait_for(lk, std::chrono::milliseconds(timeout_ms), [&]{ return !queue_.empty() || shutdown_; })) {
+			return {};
+		}
+		if (shutdown_) return {};
+		const size_t n = std::min(static_cast<size_t>(max_items), queue_.size());
+		std::vector<T> out;
+		out.reserve(n);
+		for (size_t i = 0; i < n; ++i) {
+			out.push_back(std::move(queue_.front()));
+			queue_.pop_front();
+		}
+		return out;
+	}
+
+	void Shutdown() {
+		std::lock_guard<std::mutex> lk(mutex_);
+		shutdown_ = true;
+		cv_.notify_all();
+	}
+
+	size_t Size() const {
+		std::lock_guard<std::mutex> lk(mutex_);
+		return queue_.size();
+	}
+
+private:
+	mutable std::mutex mutex_;
+	std::condition_variable cv_;
+	std::deque<T> queue_;
+	bool shutdown_ = false;
+	size_t capacity_;
+};
+
+} // namespace time::fanout_service::queues
+

--- a/time-server/src/services/fanout_service/queues/priority_queue.h
+++ b/time-server/src/services/fanout_service/queues/priority_queue.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace time::fanout_service::queues {
+
+template <typename T>
+class PriorityQueue {
+public:
+	explicit PriorityQueue(size_t capacity)
+		: capacity_(capacity) {}
+
+	bool TryPush(const T& item, int priority) {
+		std::unique_lock<std::mutex> lk(mutex_);
+		if (SizeLocked() >= capacity_) return false;
+		GetBucket(priority).push_back(item);
+		cv_.notify_one();
+		return true;
+	}
+
+	std::optional<T> PopBlocking(uint32_t timeout_ms) {
+		std::unique_lock<std::mutex> lk(mutex_);
+		if (!cv_.wait_for(lk, std::chrono::milliseconds(timeout_ms), [&]{ return SizeLocked() > 0 || shutdown_; })) {
+			return std::nullopt;
+		}
+		if (shutdown_) return std::nullopt;
+		// Higher priority first (lower numeric value = higher priority)
+		for (auto& bucket : buckets_) {
+			if (!bucket.second.empty()) {
+				T item = std::move(bucket.second.front());
+				bucket.second.pop_front();
+				return item;
+			}
+		}
+		return std::nullopt;
+	}
+
+	void Shutdown() {
+		std::lock_guard<std::mutex> lk(mutex_);
+		shutdown_ = true;
+		cv_.notify_all();
+	}
+
+private:
+	std::deque<T>& GetBucket(int priority) {
+		return buckets_[priority];
+	}
+
+	size_t SizeLocked() const {
+		size_t total = 0;
+		for (const auto& b : buckets_) total += b.second.size();
+		return total;
+	}
+
+	mutable std::mutex mutex_;
+	std::condition_variable cv_;
+	bool shutdown_ = false;
+	size_t capacity_;
+	std::map<int, std::deque<T>> buckets_;
+};
+
+} // namespace time::fanout_service::queues
+

--- a/time-server/src/services/fanout_service/service.cpp
+++ b/time-server/src/services/fanout_service/service.cpp
@@ -1,0 +1,106 @@
+#include "service.h"
+
+#include <fstream>
+#include <sstream>
+
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <spdlog/spdlog.h>
+
+namespace time::fanout_service {
+
+FanoutServer::FanoutServer(const Config& cfg) : cfg_(cfg) {}
+
+FanoutServer::~FanoutServer() { Stop(); }
+
+bool FanoutServer::Start() {
+	try {
+		auto registry = LoadRegistry(cfg_.registry_path_or_json);
+		transport_ = std::make_shared<GrpcTransport>(registry);
+		queue_ = std::make_shared<queues::BoundedQueue<time::fanout::Event>>(cfg_.queue_capacity);
+		push_ = std::make_shared<processors::PushProcessor>(queue_, cfg_.push_retries);
+		auto router = BuildRouter();
+		pull_ = std::make_shared<processors::PullProcessor>(queue_, transport_, router, cfg_.batch_size, cfg_.poll_timeout_ms);
+		pull_->Start();
+
+		controller_ = std::make_unique<controllers::FanoutController>(push_,
+				[this]{ return BuildMetrics(); },
+				[this]{ return BuildHealth(); });
+
+		grpc::ServerBuilder builder;
+		builder.AddListeningPort(cfg_.bind_address, grpc::InsecureServerCredentials());
+		builder.RegisterService(controller_.get());
+		server_ = builder.BuildAndStart();
+		return static_cast<bool>(server_);
+	} catch (const std::exception& e) {
+		spdlog::error("Failed to start FanoutServer: {}", e.what());
+		return false;
+	}
+}
+
+void FanoutServer::Stop() {
+	if (server_) {
+		server_->Shutdown();
+		server_.reset();
+	}
+	if (pull_) {
+		pull_->Stop();
+		pull_.reset();
+	}
+}
+
+std::string FanoutServer::BuildMetrics() const {
+	std::ostringstream os;
+	os << "# HELP fanout_queue_depth Current queue size\n";
+	os << "# TYPE fanout_queue_depth gauge\n";
+	os << "fanout_queue_depth " << queue_->Size() << "\n";
+	return os.str();
+}
+
+std::string FanoutServer::BuildHealth() const {
+	return "HEALTHY";
+}
+
+nlohmann::json FanoutServer::LoadRegistry(const std::string& path_or_json) {
+	if (path_or_json.empty()) {
+		// Default: discover common sibling services with standard ports
+		return nlohmann::json{
+			{"analytics_service", {{"address", "127.0.0.1:6007"}, {"method", "/time.analytics.AnalyticsService/Push"}}},
+			{"timeline_service", {{"address", "127.0.0.1:6010"}, {"method", "/time.timeline.TimelineService/Ingest"}}},
+			{"notification_service", {{"address", "127.0.0.1:6012"}, {"method", "/time.notification.NotificationService/Deliver"}}}
+		};
+	}
+	// Try read file
+	std::ifstream in(path_or_json);
+	if (in.good()) {
+		nlohmann::json j;
+		in >> j;
+		return j;
+	}
+	// Fallback: parse string as JSON
+	return nlohmann::json::parse(path_or_json);
+}
+
+std::function<std::vector<std::string>(const time::fanout::Event&)> FanoutServer::BuildRouter() {
+	return [](const time::fanout::Event& e) -> std::vector<std::string> {
+		std::vector<std::string> targets;
+		const auto& t = e.type();
+		if (t.rfind("note.", 0) == 0) {
+			targets.push_back("timeline_service");
+			targets.push_back("search_service");
+			targets.push_back("analytics_service");
+		} else if (t.rfind("user.", 0) == 0) {
+			targets.push_back("search_service");
+			targets.push_back("notification_service");
+		} else if (t.rfind("message.", 0) == 0) {
+			targets.push_back("messaging_service");
+		}
+		for (const auto& attr : e.attributes()) {
+			if (attr.key() == "target_service") targets.push_back(attr.value());
+		}
+		return targets;
+	};
+}
+
+} // namespace time::fanout_service
+

--- a/time-server/src/services/fanout_service/service.h
+++ b/time-server/src/services/fanout_service/service.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+
+#include "controllers/fanout_controller.h"
+#include "processors/pull_processor.h"
+#include "processors/push_processor.h"
+#include "transport.h"
+
+namespace time::fanout_service {
+
+struct Config {
+	std::string bind_address = "0.0.0.0:6015";
+	size_t queue_capacity = 500000;
+	uint32_t batch_size = 2048;
+	uint32_t poll_timeout_ms = 50;
+	size_t push_retries = 3;
+	// Path to registry JSON or raw JSON string
+	std::string registry_path_or_json;
+};
+
+class FanoutServer final {
+public:
+	explicit FanoutServer(const Config& cfg);
+	~FanoutServer();
+
+	bool Start();
+	void Stop();
+
+private:
+	Config cfg_{};
+	std::unique_ptr<grpc::Server> server_;
+	std::shared_ptr<processors::PushProcessor> push_;
+	std::shared_ptr<processors::PullProcessor> pull_;
+	std::shared_ptr<Transport> transport_;
+	std::shared_ptr<queues::BoundedQueue<time::fanout::Event>> queue_;
+	std::unique_ptr<controllers::FanoutController> controller_;
+
+	std::string BuildMetrics() const;
+	std::string BuildHealth() const;
+	static nlohmann::json LoadRegistry(const std::string& path_or_json);
+	static std::function<std::vector<std::string>(const time::fanout::Event&)> BuildRouter();
+};
+
+} // namespace time::fanout_service
+

--- a/time-server/src/services/fanout_service/transport.cpp
+++ b/time-server/src/services/fanout_service/transport.cpp
@@ -1,0 +1,76 @@
+#include "transport.h"
+
+#include <grpcpp/client_context.h>
+#include <grpcpp/support/byte_buffer.h>
+#include <grpcpp/support/slice.h>
+#include <spdlog/spdlog.h>
+
+namespace time::fanout_service {
+
+GrpcTransport::GrpcTransport(nlohmann::json registry) {
+	for (auto it = registry.begin(); it != registry.end(); ++it) {
+		EndpointDescriptor d;
+		d.address = it.value().value("address", "127.0.0.1:50051");
+		d.method = it.value().value("method", "/time.fanout.FanoutService/Push");
+		service_endpoints_.emplace(it.key(), std::move(d));
+	}
+}
+
+std::unique_ptr<grpc::GenericStub>& GrpcTransport::EnsureStubLocked(const std::string& service_name) {
+	auto it = stubs_.find(service_name);
+	if (it != stubs_.end()) return it->second;
+	const auto ep_it = service_endpoints_.find(service_name);
+	if (ep_it == service_endpoints_.end()) {
+		throw std::runtime_error("Missing endpoint for service: " + service_name);
+	}
+	const auto& address = ep_it->second.address;
+	auto ch_it = channels_.find(address);
+	if (ch_it == channels_.end()) {
+		auto channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+		channels_.emplace(address, channel);
+		ch_it = channels_.find(address);
+	}
+	auto stub = std::make_unique<grpc::GenericStub>(ch_it->second);
+	auto& ref = stubs_.emplace(service_name, std::move(stub)).first->second;
+	return ref;
+}
+
+std::future<bool> GrpcTransport::SendBatch(const std::string& service_name,
+											   const std::vector<time::fanout::Event>& events) {
+	return std::async(std::launch::async, [this, service_name, events]() -> bool {
+		try {
+			// Build EventBatch
+			time::fanout::EventBatch batch;
+			for (const auto& e : events) {
+				*batch.add_events() = e;
+			}
+			grpc::ClientContext ctx;
+			grpc::ByteBuffer send_buf;
+			// Serialize using protobuf into ByteBuffer
+			std::string serialized = batch.SerializeAsString();
+			grpc::Slice slice(serialized);
+			send_buf = grpc::ByteBuffer(&slice, 1);
+
+			grpc::ByteBuffer recv_buf;
+			std::string method;
+			{
+				std::lock_guard<std::mutex> lk(mutex_);
+				const auto& ep = service_endpoints_.at(service_name);
+				method = ep.method;
+				auto& stub = EnsureStubLocked(service_name);
+				auto status = stub->UnaryCall(&ctx, method, send_buf, &recv_buf);
+				if (!status.ok()) {
+					spdlog::warn("gRPC fanout to {} failed: {}", service_name, status.error_message());
+					return false;
+				}
+			}
+			return true;
+		} catch (const std::exception& e) {
+			spdlog::error("SendBatch exception for {}: {}", service_name, e.what());
+			return false;
+		}
+	});
+}
+
+} // namespace time::fanout_service
+

--- a/time-server/src/services/fanout_service/transport.h
+++ b/time-server/src/services/fanout_service/transport.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/generic/generic_stub.h>
+#include <nlohmann/json.hpp>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "proto/fanout_service.grpc.pb.h"
+
+namespace time::fanout_service {
+
+struct EndpointDescriptor {
+	std::string address;
+	std::string method; // Fully qualified RPC method, e.g. "/time.analytics.AnalyticsService/Push"
+};
+
+class Transport {
+public:
+	virtual ~Transport() = default;
+	virtual std::future<bool> SendBatch(const std::string& service_name,
+										const std::vector<time::fanout::Event>& events) = 0;
+};
+
+class GrpcTransport final : public Transport {
+public:
+	explicit GrpcTransport(nlohmann::json registry);
+	~GrpcTransport() override = default;
+	std::future<bool> SendBatch(const std::string& service_name,
+								const std::vector<time::fanout::Event>& events) override;
+
+private:
+	std::mutex mutex_;
+	std::unordered_map<std::string, EndpointDescriptor> service_endpoints_;
+	std::unordered_map<std::string, std::shared_ptr<grpc::Channel>> channels_;
+	std::unordered_map<std::string, std::unique_ptr<grpc::GenericStub>> stubs_;
+
+	std::unique_ptr<grpc::GenericStub>& EnsureStubLocked(const std::string& service_name);
+};
+
+} // namespace time::fanout_service
+


### PR DESCRIPTION
Implement the Fanout Service to reliably fan out events to downstream services with dynamic routing, batching, backpressure, and retries.

---
<a href="https://cursor.com/background-agent?bcId=bc-75827d6a-d3d4-4275-bd87-bf6f4931abc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75827d6a-d3d4-4275-bd87-bf6f4931abc3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

