### PR TITLE
Upgrade fanout service to typed gRPC contracts

### DIFF
--- a/time-server/proto/services/fanout_ingestion.proto
+++ b/time-server/proto/services/fanout_ingestion.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package sonet.fanoutin;
+
+import "services/note.proto";
+
+// Enumerates concrete event kinds supported by ingestion
+enum EventKind {
+  EVENT_KIND_UNKNOWN = 0;
+  EVENT_KIND_NOTE_CREATED = 1;
+  EVENT_KIND_NOTE_UPDATED = 2;
+  EVENT_KIND_NOTE_DELETED = 3;
+  // Future: follow events, like events, etc.
+}
+
+message NoteEvent {
+  EventKind kind = 1; // created/updated/deleted
+  sonet.note.Note note = 2;
+}
+
+// Strongly-typed envelope for events
+message EventEnvelope {
+  string id = 1;                 // globally unique event id
+  EventKind kind = 2;            // high-level kind for routing/metrics
+  oneof payload {
+    NoteEvent note_event = 10;
+    // Add future event types here (FollowEvent, LikeEvent, etc.)
+  }
+}
+
+message EventBatchRequest {
+  repeated EventEnvelope events = 1;
+}
+
+message EventBatchResponse {
+  bool accepted = 1;
+  // Optional per-event statuses in the future
+}
+
+// All downstream services that want to receive fanout must implement this
+service FanoutIngestionService {
+  rpc IngestBatch(EventBatchRequest) returns (EventBatchResponse);
+}
+

--- a/time-server/src/services/fanout_service/CMakeLists.txt
+++ b/time-server/src/services/fanout_service/CMakeLists.txt
@@ -11,6 +11,11 @@ set(PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/proto/fanout_service.proto)
 protobuf_generate_cpp(PROTO_CPP PROTO_H ${PROTO_SRC})
 grpc_generate_cpp(GRPC_CPP GRPC_H ${PROTO_SRC})
 
+# Typed ingestion contracts for downstream services
+set(INGEST_PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../../proto/services/fanout_ingestion.proto)
+protobuf_generate_cpp(INGEST_PROTO_CPP INGEST_PROTO_H ${INGEST_PROTO_SRC})
+grpc_generate_cpp(INGEST_GRPC_CPP INGEST_GRPC_H ${INGEST_PROTO_SRC})
+
 add_library(fanout_service_lib
     service.cpp
     controllers/fanout_controller.cpp
@@ -20,6 +25,8 @@ add_library(fanout_service_lib
     queues/priority_queue.cpp
     ${PROTO_CPP}
     ${GRPC_CPP}
+    ${INGEST_PROTO_CPP}
+    ${INGEST_GRPC_CPP}
 )
 
 target_include_directories(fanout_service_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/time-server/src/services/fanout_service/controllers/fanout_controller.cpp
+++ b/time-server/src/services/fanout_service/controllers/fanout_controller.cpp
@@ -21,7 +21,7 @@ bool FanoutController::load_from_dir(const std::string& dir_path) {
             EndpointDescriptor ep{};
             ep.service_name = j.value("service_name", "");
             ep.address = j.value("address", "");
-            ep.method = j.value("method", "IngestEvents");
+            ep.method = j.value("method", "IngestBatch");
             ep.max_batch_size = j.value("max_batch_size", 256);
             ep.request_timeout = std::chrono::milliseconds(j.value("request_timeout_ms", 200));
             ep.max_retry_backoff = std::chrono::milliseconds(j.value("max_retry_backoff_ms", 5000));

--- a/time-server/src/services/fanout_service/controllers/fanout_controller.h
+++ b/time-server/src/services/fanout_service/controllers/fanout_controller.h
@@ -13,7 +13,7 @@ public:
         : metrics_(std::move(metrics)) {}
 
     // Load JSON manifests from a directory. Each file describes endpoints for a logical service.
-    // Example schema: {"service_name":"timeline_service","address":"127.0.0.1:50051","method":"IngestEvents","max_batch_size":256}
+    // Example schema: {"service_name":"sonet.fanoutin.FanoutIngestionService","address":"127.0.0.1:50051","method":"IngestBatch","max_batch_size":256}
     bool load_from_dir(const std::string& dir_path);
 
     // For a single event, compute target endpoints. Returns map service_name -> EndpointDescriptor


### PR DESCRIPTION
Migrate fanout service from GenericStub + JSON payload to typed gRPC contracts for schema enforcement and robust event dispatch.

The previous fanout implementation used a generic gRPC stub with JSON payloads, lacking schema validation and type safety. This PR introduces a dedicated protobuf contract (`fanout_ingestion.proto`) and refactors the `GrpcTransport` to use a generated gRPC client stub, ensuring all events are dispatched as strongly-typed protobuf messages. This aligns the fanout service with enterprise-grade requirements for reliability and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-e94d1ddf-5cf3-4c28-9362-f889c209f62f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e94d1ddf-5cf3-4c28-9362-f889c209f62f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

