### PR TITLE
Implement fanout service with typed gRPC

### DIFF
--- a/time-server/proto/services/events.proto
+++ b/time-server/proto/services/events.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package time.events;
+
+// Base event transported across services
+message BaseEvent {
+  string id = 1;
+  string type = 2;
+  string payload_json = 3; // JSON-encoded structured payload
+}
+
+// Batch of events
+message EventBatch {
+  repeated BaseEvent events = 1;
+}
+
+// Acknowledgement
+message Ack {
+  bool ok = 1;
+  string message = 2;
+}
+
+// Sibling services implement this to receive event batches
+service Fanout {
+  rpc DeliverEvents(EventBatch) returns (Ack);
+}
+

--- a/time-server/src/services/fanout_service/CMakeLists.txt
+++ b/time-server/src/services/fanout_service/CMakeLists.txt
@@ -7,9 +7,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 find_package(Protobuf REQUIRED)
 find_package(gRPC REQUIRED)
 
-set(PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/proto/fanout_service.proto)
-protobuf_generate_cpp(PROTO_CPP PROTO_H ${PROTO_SRC})
-grpc_generate_cpp(GRPC_CPP GRPC_H ${PROTO_SRC})
+set(ADMIN_PROTO ${CMAKE_CURRENT_SOURCE_DIR}/proto/fanout_service.proto)
+set(EVENTS_PROTO ${CMAKE_SOURCE_DIR}/proto/services/events.proto)
+protobuf_generate_cpp(ADMIN_CPP ADMIN_H ${ADMIN_PROTO})
+grpc_generate_cpp(ADMIN_GRPC_CPP ADMIN_GRPC_H ${ADMIN_PROTO})
+protobuf_generate_cpp(EVENTS_CPP EVENTS_H ${EVENTS_PROTO})
+grpc_generate_cpp(EVENTS_GRPC_CPP EVENTS_GRPC_H ${EVENTS_PROTO})
 
 add_library(fanout_service_lib
     service.cpp
@@ -18,11 +21,13 @@ add_library(fanout_service_lib
     processors/push_processor.cpp
     queues/fanout_queue.cpp
     queues/priority_queue.cpp
-    ${PROTO_CPP}
-    ${GRPC_CPP}
+    ${ADMIN_CPP}
+    ${ADMIN_GRPC_CPP}
+    ${EVENTS_CPP}
+    ${EVENTS_GRPC_CPP}
 )
 
-target_include_directories(fanout_service_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(fanout_service_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/proto)
 target_link_libraries(fanout_service_lib PUBLIC gRPC::grpc++ protobuf::libprotobuf)
 
 add_executable(fanout_service main.cpp)

--- a/time-server/src/services/fanout_service/controllers/fanout_controller.cpp
+++ b/time-server/src/services/fanout_service/controllers/fanout_controller.cpp
@@ -19,9 +19,10 @@ bool FanoutController::load_from_dir(const std::string& dir_path) {
             if (!ifs) continue;
             json j; ifs >> j;
             EndpointDescriptor ep{};
-            ep.service_name = j.value("service_name", "");
+            // Support both legacy "service_name" and required "service"
+            ep.service_name = j.value("service", j.value("service_name", ""));
             ep.address = j.value("address", "");
-            ep.method = j.value("method", "IngestEvents");
+            ep.method = "DeliverEvents"; // fixed RPC for typed Fanout
             ep.max_batch_size = j.value("max_batch_size", 256);
             ep.request_timeout = std::chrono::milliseconds(j.value("request_timeout_ms", 200));
             ep.max_retry_backoff = std::chrono::milliseconds(j.value("max_retry_backoff_ms", 5000));


### PR DESCRIPTION
Implement typed gRPC for the Fanout Service by introducing a new `events.proto` and refactoring `GrpcTransport` to use generated stubs and an async `CompletionQueue`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bcaa1a21-5f50-47bf-b21e-9545e895c561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bcaa1a21-5f50-47bf-b21e-9545e895c561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

